### PR TITLE
[ICE-3619] Updating viewport service with an observer

### DIFF
--- a/addon/services/viewport.js
+++ b/addon/services/viewport.js
@@ -2,30 +2,43 @@ import Ember from 'ember';
 
 const {
   A,
-  computed
+  computed,
+  computed: { not },
+  observer,
+  Service
 } = Ember;
 
-export default Ember.Service.extend({
+export default Service.extend({
   _pool: computed(() => A()),
   isAnimating: true,
+  isNotAnimating: not('isAnimating'),
+  /**
+   * isAnimatingObserver restarts the requestAnimationFrame render loop
+   * when toggled to true.
+   */
+  isAnimatingObserver: observer('isAnimating', function() {
+    if(this.get('isAnimating')) {
+      this.flush();
+    }
+  }),
   init() {
     this.flush();
   },
   flush() {
     window.requestAnimationFrame(() => {
-      if(this.get('isAnimating')) {
-        if (this.get('isDestroying')) {
-          return;
-        }
-
-        let currentPool = this.get('_pool');
-
-        this.set('_pool', A());
-        currentPool.forEach((fn) => fn());
+      // when the service is told not to animate, stop the loop entirely
+      if(this.get('isNotAnimating') || this.get('isDestroying')) {
+        return;
       }
+
+      let currentPool = this.get('_pool');
+
+      this.set('_pool', A());
+      currentPool.forEach((fn) => fn());
       this.flush();
     });
   },
+
   add(fn) {
     this.get('_pool').pushObject(fn);
     return fn;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-in-viewport",
-  "version": "2.1.4-edmeasures",
+  "version": "2.1.5-edmeasures",
   "description": "Detect if an Ember View or Component is in the viewport @ 60FPS",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
This PR allows the rAF render loop to be completely halted and restarted on demand.